### PR TITLE
update deprecated boost url

### DIFF
--- a/io.github.Andrettin.Wyrmsun.yml
+++ b/io.github.Andrettin.Wyrmsun.yml
@@ -50,7 +50,7 @@ modules:
       - ./b2 -j${FLATPAK_BUILDER_N_JOBS} install variant=release cxxstd=11 --layout=system
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.bz2
+        url: https://archives.boost.io/release/1.69.0/source/boost_1_69_0.tar.bz2
         sha256: 8f32d4617390d1c2d16f26a27ab60d97807b35440d45891fa340fc2648b04406
 
   - name: wyrmgus


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
